### PR TITLE
fix: fix issue on isbn ten conversion ending in 11

### DIFF
--- a/app/services/isbn.rb
+++ b/app/services/isbn.rb
@@ -65,7 +65,7 @@ class ISBN
   #
   # @return [String]
   def calculate_check_digit_old(isbn)
-    new_isbn = (11 - (isbn.split(//).zip((2..10).to_a.reverse).inject(0) { |s, n| s + n[0].to_i * n[1] } % 11))
+    new_isbn = (11 - (isbn.split(//).zip((2..10).to_a.reverse).inject(0) { |s, n| s + n[0].to_i * n[1] } % 11)) % 11
 
     isbn << case new_isbn
             when 10 then 'X'

--- a/test/services/isbn_test.rb
+++ b/test/services/isbn_test.rb
@@ -28,6 +28,14 @@ class ISBNTest < ActiveSupport::TestCase
     assert_equal(expected_isbn.delete('-'), generated_isbn)
   end
 
+  def test_isbn_ten_to_isbn_thirteen_ending_in_11
+    isbn = '978-0-13409-341-3'
+    expected_isbn = '0-134-09341-0'
+    generated_isbn = @service.to_ten(isbn)
+
+    assert_equal(expected_isbn.delete('-'), generated_isbn)
+  end
+
   def test_isbn_thirteen_to_isbn_ten_ending_in_x
     isbn = '978-1-60309-038-4'
     expected_isbn = '1-603-09038-X'


### PR DESCRIPTION
# Description

Fix Issue on ISBN-10 conversion with digit ending in 11. Convert to 0 when the generated check digit is `11`

Sample ISBN-13: `9780134093413`


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshot
<img width="488" alt="Screen Shot 2023-04-13 at 4 35 39 PM" src="https://user-images.githubusercontent.com/22144212/231704603-27289077-0ed8-43c9-8235-da728dc2edad.png">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules